### PR TITLE
Modernize Qt setup with AUTORCC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 # Turn on automatic invocation of the MOC & UIC
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTORCC ON)
 
 # There may be a way to tell up front if Qt5 is going to be found, but I haven't found
 # a foolproof way to do it yet, so settle for the default error message for now.
@@ -28,11 +29,8 @@ endif()
 # Find the QtWidgets library
 find_package(Qt5 REQUIRED COMPONENTS Widgets)
 
-# Generate rules for building source files from the resources
-qt5_add_resources(QRCS resources.qrc)
-
 # Tell CMake to create the helloworld executable
-add_executable(helloworld main.cpp mainwindow.cpp mainwindow.ui ${QRCS})
+add_executable(helloworld main.cpp mainwindow.cpp mainwindow.ui resources.qrc)
 
 # Add the Qt5 Widgets for linking
 target_link_libraries(helloworld Qt5::Widgets)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(helloworld)
 # Find includes in the build directories
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-# Turn on automatic invocation of the MOC & UIC
+# Turn on automatic invocation of the MOC, UIC & RCC
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)


### PR DESCRIPTION
In the same spirit that motivated @forderud to submit PR #2, I think it would be useful to modernize the Qt-CMake-HelloWorld example by making use of the [AUTORCC](https://cmake.org/cmake/help/latest/prop_tgt/AUTORCC.html) feature, or at least let people know that this alternative is available.

Excerpt from the CMake documentation for AUTORCC:

> AUTORCC is a boolean specifying whether CMake will handle the Qt rcc code generator automatically, i.e. without having to use the QT4_ADD_RESOURCES() or QT5_ADD_RESOURCES() macro.

Changes:

- Set `CMAKE_AUTORCC` variable `ON` to handle rcc automatically for Qt targets.
- Remove `qt5_add_resources()` macro.
- Add `resources.qrc` file to `add_executable`.

Regards,

Álvaro